### PR TITLE
Make AutoSprint only activate while moving forward.

### DIFF
--- a/src/main/java/minegame159/meteorclient/modules/movement/AutoSprint.java
+++ b/src/main/java/minegame159/meteorclient/modules/movement/AutoSprint.java
@@ -18,6 +18,10 @@ public class AutoSprint extends ToggleModule {
 
     @EventHandler
     private final Listener<TickEvent> onTick = new Listener<>(event -> {
-        mc.player.setSprinting(true);
+    	if(mc.player.forwardSpeed > 0) {
+    		
+            mc.player.setSprinting(true);
+    		
+    	}
     });
 }

--- a/src/main/java/minegame159/meteorclient/modules/movement/AutoSprint.java
+++ b/src/main/java/minegame159/meteorclient/modules/movement/AutoSprint.java
@@ -5,12 +5,24 @@ import me.zero.alpine.listener.Listener;
 import minegame159.meteorclient.events.TickEvent;
 import minegame159.meteorclient.modules.Category;
 import minegame159.meteorclient.modules.ToggleModule;
+import minegame159.meteorclient.settings.BoolSetting;
+import minegame159.meteorclient.settings.Setting;
+import minegame159.meteorclient.settings.SettingGroup;
 
 public class AutoSprint extends ToggleModule {
+    private final SettingGroup sgGeneral = settings.getDefaultGroup();
+
+    private final Setting<Boolean> permanent = sgGeneral.add(new BoolSetting.Builder()
+            .name("permanent"
+            ).description("Keeps you sprinting even when you aren't moving.")
+            .defaultValue(true)
+            .build()
+    );
+	
     public AutoSprint() {
         super(Category.Movement, "auto-sprint", "Automatically sprints.");
     }
-
+    
     @Override
     public void onDeactivate() {
         mc.player.setSprinting(false);
@@ -18,10 +30,10 @@ public class AutoSprint extends ToggleModule {
 
     @EventHandler
     private final Listener<TickEvent> onTick = new Listener<>(event -> {
-    	if(mc.player.forwardSpeed > 0) {
-    		
+    	if(mc.player.forwardSpeed > 0 && !permanent.get()) {
             mc.player.setSprinting(true);
-    		
+    	} else if (permanent.get()) {
+    		mc.player.setSprinting(true);
     	}
     });
 }


### PR DESCRIPTION
This pull request will make autosprint only activate while moving forward.

If you want me to make this multidirectional I can.

Benefits of this:
- [x] More natural for the user.
- [x] Less detectable.


EDIT: The permanent sprint annoyed me a bit more than it should have while using Meteor Client.
